### PR TITLE
Bump 1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.2.5 - 2026-08-18
+
+- Fix ECS RAM Role: fall back to IMDSv1 when IMDSv2 token succeeds but later metadata requests fail.
+- Fix: treat backslash-newline as POSIX line continuation when splitting process_command.
+
 ## 1.2.0 - 2024-10-17
 
 - Refactor all credentials providers.

--- a/src/Credential.php
+++ b/src/Credential.php
@@ -29,7 +29,7 @@ class Credential
     /**
      * Version of the Client
      */
-    const VERSION = '1.1.5';
+    const VERSION = '1.2.5';
 
     /**
      * @var Config


### PR DESCRIPTION
## Summary
- Release alibabacloud/credentials 1.2.5
- Changelog: ECS IMDS v2→v1 fallback and process_command line-continuation fix